### PR TITLE
Fix highlight of first group of keywords

### DIFF
--- a/pythonhighlight.sty
+++ b/pythonhighlight.sty
@@ -46,8 +46,6 @@ emph={[2]True, False, None},
 emphstyle=[2]\color{keywordcolour},
 emph={[3]object,type,isinstance,copy,deepcopy,zip,enumerate,reversed,list,set,len,dict,tuple,xrange,append,execfile,real,imag,reduce,str,repr},
 emphstyle=[3]\color{commandcolour},
-emph={Exception,NameError,IndexError,SyntaxError,TypeError,ValueError,OverflowError,ZeroDivisionError},
-emphstyle=\color{exceptioncolour}\bfseries,
 %upquote=true,
 morecomment=[s]{"""}{"""},
 commentstyle=\color{commentcolour}\slshape,
@@ -62,6 +60,8 @@ emph={[7]range},
 emphstyle={[7]\color{keywordcolour}\bfseries},
 % emph={[7]self},
 % emphstyle=[7]\bfseries,
+emph={[8]Exception,NameError,IndexError,SyntaxError,TypeError,ValueError,OverflowError,ZeroDivisionError},
+emphstyle=[8]\color{exceptioncolour}\bfseries,
 literate=*%
 {:}{{\literatecolour:}}{1}%
 {=}{{\literatecolour=}}{1}%


### PR DESCRIPTION
The definition of the first group (`and`, `break`, etc.) is overridden by the Exception group (`Exception`, `NameError`, etc.). So they are not colored in blue.

The patch provides a number to the Exception group to solve the issue. The group is moved in the 8th place so the order is not surprising (1, 2, 3, 8, 4, etc.).