### PR TITLE
Add three keywords: as, async and await

### DIFF
--- a/pythonhighlight.sty
+++ b/pythonhighlight.sty
@@ -38,7 +38,7 @@ showstringspaces=false,
 alsoletter={1234567890},
 otherkeywords={\%, \}, \{, \&, \|},
 keywordstyle=\color{keywordcolour}\bfseries,
-emph={and,break,class,continue,def,yield,del,elif ,else,%
+emph={and,as,async,await,break,class,continue,def,yield,del,elif ,else,%
 except,exec,finally,for,from,global,if,import,in,%
 lambda,not,or,pass,print,raise,return,try,while,assert,with},
 emphstyle=\color{blue}\bfseries,


### PR DESCRIPTION
This PR adds `as`, `async` and `await` as new keywords.
The 2 latter keywords have been promoted in python 3.7:
https://docs.python.org/3.7/whatsnew/changelog.html#id74 (last item)

The fix #8 needs to be applied before in order to see the highlight in .pdf file.

I wonder if `open()` should be added to the commandkeywords (`object`, `type`, etc.).