### PR TITLE
Update pythonhighlight.sty

### DIFF
--- a/pythonhighlight.sty
+++ b/pythonhighlight.sty
@@ -1,4 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
+\UseRawInputEncoding
 \ProvidesPackage{pythonhighlight}[2011/09/19 python code highlighting; provided by Olivier Verdier <olivier.verdier@gmail.com>]
 
 


### PR DESCRIPTION
adding \UseRawInputEncoding to prevent latex errors related to UTF-8 or the type:

! Package inputenc Error: Invalid UTF-8 byte sequence. This happens in the following snippet (inside of a beamer project with UTF8 encoding):

\begin{python}
# define a function
def add_one(n):
    return n + 1

# run the function specifying 41 as input
result = add_one(41)​

# print the result stored in the variable result
print(result)
\end{python}